### PR TITLE
Fix nil pointer dereference during domain creation error handling

### DIFF
--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -235,7 +235,7 @@ func resourceMailgunDomainRead(ctx context.Context, d *schema.ResourceData, meta
 	_, err := resourceMailgunDomainRetrieve(d.Id(), client, d)
 
 	if err != nil {
-		return diag.FromErr(errc)
+		return diag.FromErr(err)
 	}
 
 	return nil


### PR DESCRIPTION
Most likely a typo, but it could lead to

```
2021-01-05T11:37:19.480+0100 [DEBUG] plugin.terraform-provider-mailgun_v0.5.4: panic: runtime error: invalid memory address or nil pointer dereference
2021-01-05T11:37:19.480+0100 [DEBUG] plugin.terraform-provider-mailgun_v0.5.4: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1b0051b]
```

in some cases.