### PR TITLE
Add DKIM Key Size to the Domain Resource

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -18,6 +18,7 @@ resource "mailgun_domain" "default" {
   region        = "us"
   spam_action   = "disabled"
   smtp_password   = "supersecretpassword1234"
+  dkim_key_size   = 1024
 }
 ```
 
@@ -33,6 +34,7 @@ The following arguments are supported:
     will be tagged with a spam header.
 * `wildcard` - (Optional) Boolean that determines whether
     the domain will accept email for sub-domains.
+* `dkim_key_size` - (Optional) The length of your domain’s generated DKIM key. Default value is `1024`.
 
 ## Attributes Reference
 

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -109,6 +109,12 @@ func resourceMailgunDomain() *schema.Resource {
 					},
 				},
 			},
+			"dkim_key_size": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  1024,
+			},
 		},
 	}
 }
@@ -169,6 +175,7 @@ func resourceMailgunDomainCreate(ctx context.Context, d *schema.ResourceData, me
 	opts.SpamAction = mailgun.SpamAction(d.Get("spam_action").(string))
 	opts.Password = d.Get("smtp_password").(string)
 	opts.Wildcard = d.Get("wildcard").(bool)
+	opts.DKIMKeySize = d.Get("dkim_key_size").(int)
 
 	log.Printf("[DEBUG] Domain create configuration: %#v", opts)
 

--- a/mailgun/resource_mailgun_domain_test.go
+++ b/mailgun/resource_mailgun_domain_test.go
@@ -62,6 +62,7 @@ func TestAccMailgunDomain_Import(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{"dkim_key_size"},
 			},
 		},
 	})


### PR DESCRIPTION
**Description**:
The PR adds the dkim_key_size to the Domain Resource. This will helpful to create Mailgun domains with 2048 DKIM key size.

**Why didn't we update the data source?**
The mailgun-go client used by this provider doesn't expose DkimKeySize in the DomainResponse (link)[https://github.com/mailgun/mailgun-go/blob/9c39a971e10acf0fde95aa577a29e741dad2a0db/domains.go#L22-L42](url)

**Why are there no tests for DKIM Key Size?** 
I didn't see a test for the DomainCreate function. I have added the dkim_key_size under ImportStateVerifyIgnore since it's not possible to d.Set() the attribute in the Read function

**Output**: 

**Unit test:** 
<img width="1063" alt="Screen Shot 2021-02-03 at 12 33 22 PM" src="https://user-images.githubusercontent.com/1827694/106785973-07bee300-661c-11eb-8fe5-294f3558c5c1.png">

**Acceptance test:** 
<img width="662" alt="Screen Shot 2021-02-03 at 12 34 37 PM" src="https://user-images.githubusercontent.com/1827694/106786120-3210a080-661c-11eb-81c1-aa70b72a85aa.png">