### PR TITLE
Small documentation updates

### DIFF
--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -14,8 +14,8 @@ data "mailgun_domain" "domain" {
 }
 
 resource "aws_route53_record" "mailgun-mx" {
-  zone_id = "${var.zone_id}"
-  name    = "${data.mailgun.domain.name}"
+  zone_id = var.zone_id
+  name    = data.mailgun.domain.name
   type    = "MX"
   ttl     = 3600
   records = [

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -17,8 +17,8 @@ resource "mailgun_domain" "default" {
   name          = "test.example.com"
   region        = "us"
   spam_action   = "disabled"
-  smtp_password   = "supersecretpassword1234"
-  dkim_key_size   = 1024
+  smtp_password = "supersecretpassword1234"
+  dkim_key_size = 1024
 }
 ```
 
@@ -63,5 +63,5 @@ The following attributes are exported:
 Domains can be imported using `region:domain_name` via `import` command. Region has to be chosen from `eu` or `us` (when no selection `us` is applied). 
 
 ```hcl
-terraform import mailgun_domain.test us:example.domain.com
+terraform import mailgun_domain.test us:subdomain.example.com
 ```

--- a/docs/resources/domain_credential.md
+++ b/docs/resources/domain_credential.md
@@ -13,14 +13,14 @@ Provides a Mailgun domain credential resource. This can be used to create and ma
 ```hcl
 # Create a new Mailgun credential
 resource "mailgun_domain_credential" "foobar" {
-	domain = "toto.com"
-	email = "test@toto.com"
-	password = "supersecretpassword1234"
-	region = "us"
-	
-	lifecycle {
-	    ignore_changes = [ "password" ]
-	}
+  domain   = "example.com"
+  login    = "test"
+  password = "supersecretpassword1234"
+  region   = "us"
+
+  lifecycle {
+    ignore_changes = [password]
+  }
 }
 ```
 
@@ -29,7 +29,7 @@ resource "mailgun_domain_credential" "foobar" {
 The following arguments are supported:
 
 * `domain` - (Required) The domain to add credential of Mailgun.
-* `email` - (Required) The email address to create.
+* `login` - (Required) The local-part of the email address to create.
 * `password` - (Required) Password for user authentication.
 * `region` - (Optional) The region where domain will be created. Default value is `us`.
 
@@ -38,7 +38,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `domain` - The name of the domain.
-* `email` - The email address.
+* `login` - The local-part of the email address.
 * `password` - Password for user authentication.
 * `region` - The name of the region.
 
@@ -48,5 +48,5 @@ Domain credential can be imported using `region:email` via `import` command. Reg
 Password is always exported to `null`.
 
 ```hcl
-terraform import mailgun_domain_credential.test us:test@domain.com
+terraform import mailgun_domain_credential.test us:test@example.com
 ```

--- a/docs/resources/route.md
+++ b/docs/resources/route.md
@@ -11,13 +11,13 @@ Provides a Mailgun Route resource. This can be used to create and manage routes 
 ```hcl
 # Create a new Mailgun route
 resource "mailgun_route" "default" {
-    priority = "0"
-    description = "inbound"
-    expression = "match_recipient('.*@foo.example.com')"
-    actions = [
-        "forward('http://example.com/api/v1/foos/')",
-        "stop()"
-    ]
+  priority    = "0"
+  description = "inbound"
+  expression  = "match_recipient('.*@foo.example.com')"
+  actions = [
+    "forward('http://example.com/api/v1/foos/')",
+    "stop()"
+  ]
 }
 ```
 
@@ -26,7 +26,7 @@ resource "mailgun_route" "default" {
 The following arguments are supported:
 * `priority` - (Required) Smaller number indicates higher priority. Higher priority routes are handled first.
 * `description` - (Required)
-* `expression` - (Required) A filter expression like `match_recipient('.*@gmail.com')`
+* `expression` - (Required) A filter expression like `match_recipient('.*@example.com')`
 * `action` - (Required) Route action. This action is executed when the expression evaluates to True. Example: `forward("alice@example.com")` You can pass multiple `action` parameters.
 * `region` - (Optional) The region where domain will be created. Default value is `us`.
 


### PR DESCRIPTION
This fixes four things.

- The `email` field in `domain_credential` was replaced with `login` in b4b1cef2fdb70acff51afc871ccf4b58a4e27511. This updates the corresponding documentation.
- Quoted references are deprecated since Terraform 0.11.
- Use RFC6761 6.5 domains for examples.
- Run `terraform fmt` on all examples

----

I target the branch `add_credential_support_origin`. It seems like it should be merged into `master` first.