### PR TITLE
Update Domain Credential Docs

### DIFF
--- a/docs/resources/domain_credential.md
+++ b/docs/resources/domain_credential.md
@@ -14,7 +14,7 @@ Provides a Mailgun domain credential resource. This can be used to create and ma
 # Create a new Mailgun credential
 resource "mailgun_domain_credential" "foobar" {
 	domain = "toto.com"
-	email = "test@toto.com"
+	login = "test"
 	password = "supersecretpassword1234"
 	region = "us"
 	
@@ -29,7 +29,7 @@ resource "mailgun_domain_credential" "foobar" {
 The following arguments are supported:
 
 * `domain` - (Required) The domain to add credential of Mailgun.
-* `email` - (Required) The email address to create.
+* `login` - (Required) The local-part of the email address to create.
 * `password` - (Required) Password for user authentication.
 * `region` - (Optional) The region where domain will be created. Default value is `us`.
 


### PR DESCRIPTION
The module documentation does not align with the schema for the domain credential resource type.

https://github.com/wgebis/terraform-provider-mailgun/blob/master/docs/resources/domain_credential.md?plain=1#L17 indicates the module requires the attribute "email" and uses the entire email as the value. However, https://github.com/wgebis/terraform-provider-mailgun/blob/master/mailgun/resource_mailgun_credential.go#L28 shows that the actual attribute required is called "login" and it is in the form of the email's local-part (https://github.com/wgebis/terraform-provider-mailgun/blob/master/mailgun/resource_mailgun_credential.go#L72).
