### PR TITLE
feat: use a custom diff + new `id` attr on record attrs to allow using them with `for_each`

### DIFF
--- a/mailgun/mailgun_helper.go
+++ b/mailgun/mailgun_helper.go
@@ -2,6 +2,7 @@ package mailgun
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"hash/crc32"
 	"strings"
 )
 
@@ -14,4 +15,21 @@ func setDefaultRegionForImport(d *schema.ResourceData) {
 		d.Set("region", parts[0])
 		d.SetId(parts[1])
 	}
+}
+
+// stringHashcode hashes a string to a unique hashcode.
+//
+// crc32 returns a uint32, but for our use we need
+// and non negative integer. Here we cast to an integer
+// and invert it if the result is negative.
+func stringHashcode(s string) int {
+	v := int(crc32.ChecksumIEEE([]byte(s)))
+	if v >= 0 {
+		return v
+	}
+	if -v >= 0 {
+		return -v
+	}
+	// v == MinInt
+	return 0
 }

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
-	"hash/crc32"
 	"log"
 	"strings"
 	"time"
@@ -162,23 +161,6 @@ func resourceMailgunDomain() *schema.Resource {
 	}
 }
 
-// StringHashcode hashes a string to a unique hashcode.
-//
-// crc32 returns a uint32, but for our use we need
-// and non negative integer. Here we cast to an integer
-// and invert it if the result is negative.
-func StringHashcode(s string) int {
-	v := int(crc32.ChecksumIEEE([]byte(s)))
-	if v >= 0 {
-		return v
-	}
-	if -v >= 0 {
-		return -v
-	}
-	// v == MinInt
-	return 0
-}
-
 func domainRecordsSchemaSetFunc(v interface{}) int {
 	m, ok := v.(map[string]interface{})
 
@@ -187,7 +169,7 @@ func domainRecordsSchemaSetFunc(v interface{}) int {
 	}
 
 	if v, ok := m["id"].(string); ok {
-		return StringHashcode(v)
+		return stringHashcode(v)
 	}
 
 	return 0

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -96,7 +96,7 @@ func resourceMailgunDomain() *schema.Resource {
 			"sending_records": &schema.Schema{
 				Type:     schema.TypeSet,
 				Computed: true,
-				Set:      acmDomainValidationOptionsHash,
+				Set:      domainRecordsSchemaSetFunc,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -137,8 +137,8 @@ func resourceMailgunDomain() *schema.Resource {
 					items = append(items, map[string]interface{}{"id": "_domainkey." + diff.Get("name").(string)})
 					items = append(items, map[string]interface{}{"id": "email." + diff.Get("name").(string)})
 
-					if err := diff.SetNew("sending_records", schema.NewSet(acmDomainValidationOptionsHash, items)); err != nil {
-						return fmt.Errorf("error setting new domain_validation_options diff: %w", err)
+					if err := diff.SetNew("sending_records", schema.NewSet(domainRecordsSchemaSetFunc, items)); err != nil {
+						return fmt.Errorf("error setting new sending_records diff: %w", err)
 					}
 				}
 
@@ -165,7 +165,7 @@ func StringHashcode(s string) int {
 	return 0
 }
 
-func acmDomainValidationOptionsHash(v interface{}) int {
+func domainRecordsSchemaSetFunc(v interface{}) int {
 	m, ok := v.(map[string]interface{})
 
 	if !ok {

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -69,10 +69,15 @@ func resourceMailgunDomain() *schema.Resource {
 			},
 
 			"receiving_records": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Computed: true,
+				Set:      domainRecordsSchemaSetFunc,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 						"priority": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -131,14 +136,23 @@ func resourceMailgunDomain() *schema.Resource {
 		CustomizeDiff: customdiff.Sequence(
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
 				if diff.HasChange("name") {
-					var items []interface{}
+					var sendingRecords []interface{}
 
-					items = append(items, map[string]interface{}{"id": diff.Get("name").(string)})
-					items = append(items, map[string]interface{}{"id": "_domainkey." + diff.Get("name").(string)})
-					items = append(items, map[string]interface{}{"id": "email." + diff.Get("name").(string)})
+					sendingRecords = append(sendingRecords, map[string]interface{}{"id": diff.Get("name").(string)})
+					sendingRecords = append(sendingRecords, map[string]interface{}{"id": "_domainkey." + diff.Get("name").(string)})
+					sendingRecords = append(sendingRecords, map[string]interface{}{"id": "email." + diff.Get("name").(string)})
 
-					if err := diff.SetNew("sending_records", schema.NewSet(domainRecordsSchemaSetFunc, items)); err != nil {
+					if err := diff.SetNew("sending_records", schema.NewSet(domainRecordsSchemaSetFunc, sendingRecords)); err != nil {
 						return fmt.Errorf("error setting new sending_records diff: %w", err)
+					}
+
+					var receivingRecords []interface{}
+
+					receivingRecords = append(receivingRecords, map[string]interface{}{"id": "mxa.mailgun.org"})
+					receivingRecords = append(receivingRecords, map[string]interface{}{"id": "mxb.mailgun.org"})
+
+					if err := diff.SetNew("receiving_records", schema.NewSet(domainRecordsSchemaSetFunc, receivingRecords)); err != nil {
+						return fmt.Errorf("error setting new receiving_records diff: %w", err)
 					}
 				}
 
@@ -327,6 +341,7 @@ func resourceMailgunDomainRetrieve(id string, client *mailgun.MailgunImpl, d *sc
 	receivingRecords := make([]map[string]interface{}, len(resp.ReceivingDNSRecords))
 	for i, r := range resp.ReceivingDNSRecords {
 		receivingRecords[i] = make(map[string]interface{})
+		receivingRecords[i]["id"] = r.Value
 		receivingRecords[i]["priority"] = r.Priority
 		receivingRecords[i]["valid"] = r.Valid
 		receivingRecords[i]["value"] = r.Value

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -3,12 +3,12 @@ package mailgun
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"log"
 	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mailgun/mailgun-go/v4"

--- a/mailgun/resource_mailgun_domain_test.go
+++ b/mailgun/resource_mailgun_domain_test.go
@@ -3,6 +3,7 @@ package mailgun
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-uuid"
@@ -15,6 +16,7 @@ func TestAccMailgunDomain_Basic(t *testing.T) {
 	var resp mailgun.DomainResponse
 	uuid, _ := uuid.GenerateUUID()
 	domain := fmt.Sprintf("terraform.%s.com", uuid)
+	re := regexp.MustCompile(`^\w+\._domainkey\.` + regexp.QuoteMeta(domain))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -34,8 +36,8 @@ func TestAccMailgunDomain_Basic(t *testing.T) {
 						"mailgun_domain.foobar", "wildcard", "true"),
 					resource.TestCheckResourceAttr(
 						"mailgun_domain.foobar", "receiving_records.0.priority", "10"),
-					resource.TestCheckResourceAttr(
-						"mailgun_domain.foobar", "sending_records.0.name", domain),
+					resource.TestMatchResourceAttr(
+						"mailgun_domain.foobar", "sending_records.0.name", re),
 				),
 			},
 		},


### PR DESCRIPTION
Because of the way Terraform works, you currently cannot use `sending_records` or `receiving_records` in a `for_each` as they're an arbitrary list set by the API response.

Attempting to do so will cause an error:

 ```
╷
│ Error: Invalid for_each argument
│
│   on main.tf line 60, in resource "cloudflare_record" "mailgun_records":
│   60:   for_each = {
│   61:     for record in mailgun_domain.default.sending_records : record.name => {
│   62:       type = record.record_type
│   63:       name = record.name
│   64:       value = record.value
│   65:     }
│   66:   }
│     ├────────────────
│     │ mailgun_domain.default.sending_records is a list of object, known only after apply
│
│ The "for_each" value depends on resource attributes that cannot be determined until apply, so Terraform cannot
│ predict how many instances will be created. To work around this, use the -target argument to first apply only
│ the resources that the for_each depends on.
╵
```

This is annoying because it means we have to manually setup DNS records in e.g. CloudFlare despite having a Terraform provider that lets us create DNS records 😭  

There are two requirements that must be meet for Terraform to be able to plan the above:
  1. The set must have a fixed number items (technically you can get away with more items being added by the read, but that will result in having to do two applies back-to-back to ensure your state is up to date)
  2. _one_ of those properties must be static, in order to be able to provide a consistent _plannable_ ID for the Set

That is what this PR attempts to do, working off the fact that we know the number of records that we'll be provided by the API (3, for `sending_records`), and what those record names actually are... almost.

The edge case we have to handle is that one of the three records (the `_domainkey` record) we expect has a random prefix to it, which means we cannot use `name` itself as the field to compute the stable `id` for the Set, since that will result in at best an unstable diff.

We work around by adding a new `id` attribute to the `sending_records` map, which is effectively a normalised version of each records name - which is to say for two of the three records it is their name, but for the `_domainkey` record we drop the random prefix.

This allows us to do this:

```
data "cloudflare_zone" "root" {
  name = local.app_root_domain
}

resource "mailgun_domain" "default" {
  name        = local.app_full_domain
  wildcard    = false
  spam_action = "disabled"
}

resource "cloudflare_record" "mailgun_records" {
  for_each = {
    for record in mailgun_domain.default.sending_records : record.id => {
      type  = record.record_type
      name  = record.name
      value = record.value
    }
  }

  type    = each.value.type
  name    = each.value.name
  value   = each.value.value
  zone_id = data.cloudflare_zone.root.zone_id
  proxied = false

  depends_on = [mailgun_domain.default]
}
```

```
mailgun_domain.default: Creating...
mailgun_domain.default: Creation complete after 4s [id=example.com]
cloudflare_record.mailgun_records["email.example.com"]: Creating...
cloudflare_record.mailgun_records["_domainkey.example.com"]: Creating...
cloudflare_record.mailgun_records["example.com"]: Creating...
cloudflare_record.mailgun_records["email.example.com"]: Creation complete after 1s [id=ec8884a85b1b2a7390568ab4be549a3c]
cloudflare_record.mailgun_records["_domainkey.example.com"]: Creation complete after 1s [id=9012e7c43698cc96d22eb4e70d0712cf]
cloudflare_record.mailgun_records["example.com"]: Creation complete after 2s [id=87b932427914022d79707becfb37a5cd]
```

----

This was shamelessly ripped off the `aws_acm_certificate` resource, which does almost the same thing using the `domain_name` (related PR https://github.com/hashicorp/terraform-provider-aws/pull/14199)

~I'm opening this as a draft for now as I'm cleaning up the code and still have to apply it to the receiving records attribute, but wanted to try and get a review going especially because~ I don't know how well I'll be able to actually write tests for this 😬 

I can say that I've tested this a bunch locally, and I believe if MailGun were to suddenly add a new record that shouldn't cause the provider to fall over as a result of this change - especially since we're always setting an ID, so if anything breaks it would be `for_each`s which are already broken right now anyway so this would still be better than what happens currently 😅 