### PR TITLE
Add missing region argument documentation to data source

### DIFF
--- a/docs/data-sources/domain.md
+++ b/docs/data-sources/domain.md
@@ -27,7 +27,8 @@ resource "aws_route53_record" "mailgun-mx" {
 
 ## Argument Reference
 
-* `name` - The name of the domain.
+* `name` - (Required) The name of the domain.
+* `region` - (Optional) The region where domain will be created. Default value is `us`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Region argument exists for data source as well but it just wasn't in the documentation. I copied over the documentation for region from resource docs.