### PR TITLE
resource domain: add support of `force_dkim_authority`

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -36,7 +36,7 @@ The following arguments are supported:
     the domain will accept email for sub-domains.
 * `dkim_key_size` - (Optional) The length of your domain’s generated DKIM key. Default value is `1024`.
 * `dkim_selector` - (Optional) The name of your DKIM selector if you want to specify it whereas MailGun will make it's own choice.
-* `force_dkim_authority` - (Optional) If set to true, the domain will be the DKIM authority for itself even if the root domain is registered on the same mailgun account. If set to false, the domain will have the same DKIM authority as the root domain registered on the same mailgun account
+* `force_dkim_authority` - (Optional) If set to true, the domain will be the DKIM authority for itself even if the root domain is registered on the same mailgun account. If set to false, the domain will have the same DKIM authority as the root domain registered on the same mailgun account. The default is `false`.
 
 ## Attributes Reference
 

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -36,6 +36,7 @@ The following arguments are supported:
     the domain will accept email for sub-domains.
 * `dkim_key_size` - (Optional) The length of your domain’s generated DKIM key. Default value is `1024`.
 * `dkim_selector` - (Optional) The name of your DKIM selector if you want to specify it whereas MailGun will make it's own choice.
+* `force_dkim_authority` - (Optional) If set to true, the domain will be the DKIM authority for itself even if the root domain is registered on the same mailgun account. If set to false, the domain will have the same DKIM authority as the root domain registered on the same mailgun account
 
 ## Attributes Reference
 

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -119,6 +119,11 @@ func resourceMailgunDomain() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"force_dkim_authority": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -173,6 +178,7 @@ func resourceMailgunDomainCreate(ctx context.Context, d *schema.ResourceData, me
 	opts.Password = d.Get("smtp_password").(string)
 	opts.Wildcard = d.Get("wildcard").(bool)
 	opts.DKIMKeySize = d.Get("dkim_key_size").(int)
+	opts.ForceDKIMAuthority = d.Get("force_dkim_authority").(bool)
 	var dkimSelector = d.Get("dkim_selector").(string)
 
 	log.Printf("[DEBUG] Domain create configuration: %#v", opts)


### PR DESCRIPTION
https://documentation.mailgun.com/en/latest/api-domains.html#domains

> force_dkim_authority | true or false
> If set to true, the domain will be the DKIM authority for itself even if the root domain is registered on the same mailgun accountIf set to false, the domain will have the same DKIM authority as the root domain registered on the same mailgun accountThe default is false.

