### PR TITLE
feat: add `receiving_records_set` and `sending_records_set` attributes

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -52,7 +52,17 @@ The following attributes are exported:
     * `record_type` - The record type.
     * `valid` - `"valid"` if the record is valid.
     * `value` - The value of the record.
+* `receiving_records_set` - A set of DNS records for receiving validation.
+    * `priority` - The priority of the record.
+    * `record_type` - The record type.
+    * `valid` - `"valid"` if the record is valid.
+    * `value` - The value of the record.
 * `sending_records` - A list of DNS records for sending validation.
+    * `name` - The name of the record.
+    * `record_type` - The record type.
+    * `valid` - `"valid"` if the record is valid.
+    * `value` - The value of the record.
+* `sending_records_set` - A set of DNS records for sending validation.
     * `name` - The name of the record.
     * `record_type` - The record type.
     * `valid` - `"valid"` if the record is valid.

--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -47,7 +47,7 @@ The following attributes are exported:
 * `smtp_password` - The password to the SMTP server.
 * `wildcard` - Whether or not the domain will accept email for sub-domains.
 * `spam_action` - The spam filtering setting.
-* `receiving_records` - A list of DNS records for receiving validation.
+* `receiving_records` - A list of DNS records for receiving validation.  **Deprecated** Use `receiving_records_set` instead.
     * `priority` - The priority of the record.
     * `record_type` - The record type.
     * `valid` - `"valid"` if the record is valid.
@@ -57,7 +57,7 @@ The following attributes are exported:
     * `record_type` - The record type.
     * `valid` - `"valid"` if the record is valid.
     * `value` - The value of the record.
-* `sending_records` - A list of DNS records for sending validation.
+* `sending_records` - A list of DNS records for sending validation. **Deprecated** Use `sending_records_set` instead.
     * `name` - The name of the record.
     * `record_type` - The record type.
     * `valid` - `"valid"` if the record is valid.

--- a/mailgun/mailgun_helper.go
+++ b/mailgun/mailgun_helper.go
@@ -2,6 +2,7 @@ package mailgun
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"hash/crc32"
 	"strings"
 )
 
@@ -14,4 +15,21 @@ func setDefaultRegionForImport(d *schema.ResourceData) {
 		d.Set("region", parts[0])
 		d.SetId(parts[1])
 	}
+}
+
+// stringHashcode hashes a string to a unique hashcode.
+//
+// crc32 returns a uint32, but for our use we need
+// and non negative integer. Here we cast to an integer
+// and invert it if the result is negative.
+func stringHashcode(s string) int {
+	v := int(crc32.ChecksumIEEE([]byte(s)))
+	if v >= 0 {
+		return v
+	}
+	if -v >= 0 {
+		return -v
+	}
+	// v == MinInt
+	return 0
 }

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -68,8 +68,9 @@ func resourceMailgunDomain() *schema.Resource {
 			},
 
 			"receiving_records": &schema.Schema{
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:       schema.TypeList,
+				Computed:   true,
+				Deprecated: "Use `receiving_records_set` instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -127,8 +128,9 @@ func resourceMailgunDomain() *schema.Resource {
 			},
 
 			"sending_records": &schema.Schema{
-				Type:     schema.TypeList,
-				Computed: true,
+				Type:       schema.TypeList,
+				Computed:   true,
+				Deprecated: "Use `sending_records_set` instead.",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {

--- a/mailgun/resource_mailgun_domain_test.go
+++ b/mailgun/resource_mailgun_domain_test.go
@@ -3,6 +3,7 @@ package mailgun
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/go-uuid"
@@ -15,6 +16,7 @@ func TestAccMailgunDomain_Basic(t *testing.T) {
 	var resp mailgun.DomainResponse
 	uuid, _ := uuid.GenerateUUID()
 	domain := fmt.Sprintf("terraform.%s.com", uuid)
+	re := regexp.MustCompile(`^\w+\._domainkey\.` + regexp.QuoteMeta(domain))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -36,6 +38,8 @@ func TestAccMailgunDomain_Basic(t *testing.T) {
 						"mailgun_domain.foobar", "receiving_records.0.priority", "10"),
 					resource.TestCheckResourceAttr(
 						"mailgun_domain.foobar", "sending_records.0.name", domain),
+					resource.TestMatchResourceAttr(
+						"mailgun_domain.foobar", "sending_records_set.0.name", re),
 				),
 			},
 		},


### PR DESCRIPTION
This re-lands #27 in the form of new attributes so that users can easily migrate.

It means that people can use `for_each` to safely generate records by using the ID as a static value at plan time, taking you from this:

```
│ Error: Invalid for_each argument
│
│   on main.tf line 98, in resource "aws_route53_record" "mailgun_records":
│   98:   for_each = {
│   99:     for record in mailgun_domain.default.sending_records : record.id => {
│  100:       type  = record.record_type
│  101:       name  = record.name
│  102:       value = record.value
│  103:     }
│  104:   }
│     ├────────────────
│     │ mailgun_domain.default.sending_records is a list of object, known only after apply
│
│ The "for_each" map includes keys derived from resource attributes that cannot be determined until apply, and so
│ Terraform cannot determine the full set of keys that will identify the instances of this resource.
│
│ When working with unknown values in for_each, it's better to define the map keys statically in your configuration and
│ place apply-time results only in the map values.
│
│ Alternatively, you could use the -target planning option to first apply only the resources that the for_each value
│ depends on, and then apply a second time to fully converge.
```

to this (when replacing `sending_records` with `sending_records_set`):

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:
  ...

Plan: 5 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value:

```

-----

@wgebis do you want to deprecate the old attributes, or keep them around for the foreseeable future? I don't think its the end of the world to keep them around but as discussed in the original PR the set is arguably nicer and you can convert it back to a list if needed.

If you do think we should deprecate, then I wonder if we should actually consider landing the original change and introducing `_list` attributes instead because otherwise I expect we'll end up doing `sending_records -> sending_records_set -> sending_records` which'll be a bit odd.