### PR TITLE
Update resourceMailgunDomainDelete to use 5 minute timeout

### DIFF
--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -367,7 +367,7 @@ func resourceMailgunDomainDelete(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	// Give the destroy a chance to take effect
-	err = resource.RetryContext(ctx, 1*time.Minute, func() *resource.RetryError {
+	err = resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
 		_, err = client.GetDomain(ctx, d.Id())
 		if err == nil {
 			log.Printf("[INFO] Retrying until domain disappears...")


### PR DESCRIPTION
I updated the timeout for the delete operation which I see some people are running into troubles with being too short, including me. I dont know if this tiny edit satisfies the requirements for a PR, but its worth a shot. 🤞