### PR TITLE
Fix recreate if `spam_action` not set

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `smtp_password` - (Optional) Password for SMTP authentication
 * `spam_action` - (Optional) `disabled` or `tag` Disable, no spam
     filtering will occur for inbound messages. Tag, messages
-    will be tagged with a spam header.
+    will be tagged with a spam header. Default value is `disabled`.
 * `wildcard` - (Optional) Boolean that determines whether
     the domain will accept email for sub-domains.
 * `dkim_key_size` - (Optional) The length of your domain’s generated DKIM key. Default value is `1024`.

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -41,6 +41,7 @@ func resourceMailgunDomain() *schema.Resource {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
+				Default:  "disabled",
 			},
 
 			"smtp_login": {


### PR DESCRIPTION
This PR stops the provider forcing a recreation of a domain if the optional `spam_action` argument is not set on the resource. 

Resolves #40