### PR TITLE
Fix route resource state inconsistency and API base URL configuration

### DIFF
--- a/mailgun/config.go
+++ b/mailgun/config.go
@@ -1,6 +1,7 @@
 package mailgun
 
 import (
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/mailgun/mailgun-go/v5"
 	"log"
@@ -27,15 +28,28 @@ func (c *Config) GetClient(Region string) (*mailgun.Client, error) {
 
 	c.MailgunClient = mailgun.NewMailgun(c.APIKey)
 	c.Region = Region
-	c.ConfigureBaseUrl(Region)
+	err := c.ConfigureBaseUrl(Region)
+	if err != nil {
+		return nil, fmt.Errorf("Error configuring base URL: %s", err)
+	}
 
 	return c.MailgunClient, nil
 }
 
-func (c *Config) ConfigureBaseUrl(Region string) {
+func (c *Config) ConfigureBaseUrl(Region string) error {
+	var baseUrl string
 	if strings.ToLower(Region) == "eu" {
-		_ = c.MailgunClient.SetAPIBase("https://api.eu.mailgun.net/v3")
+		baseUrl = "https://api.eu.mailgun.net"
 	} else {
-		_ = c.MailgunClient.SetAPIBase("https://api.mailgun.net/v3")
+		baseUrl = "https://api.mailgun.net"
 	}
+	
+	log.Printf("[DEBUG] Setting Mailgun API base URL for region %s: %s", Region, baseUrl)
+	err := c.MailgunClient.SetAPIBase(baseUrl)
+	if err != nil {
+		return fmt.Errorf("Error setting API base URL to %s: %s", baseUrl, err)
+	}
+	
+	log.Printf("[DEBUG] Successfully configured Mailgun client for region %s", Region)
+	return nil
 }

--- a/mailgun/data_source_mailgun_domain.go
+++ b/mailgun/data_source_mailgun_domain.go
@@ -1,6 +1,7 @@
 package mailgun
 
 import (
+	"log"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -15,12 +16,15 @@ func dataSourceMailgunDomain() *schema.Resource {
 }
 
 func dataSourceMailgunDomainRead(d *schema.ResourceData, meta interface{}) error {
-	client, errc := meta.(*Config).GetClient(d.Get("region").(string))
+	region := d.Get("region").(string)
+	name := d.Get("name").(string)
+	
+	log.Printf("[DEBUG] Reading Mailgun domain: name=%s, region=%s", name, region)
+	
+	client, errc := meta.(*Config).GetClient(region)
 	if errc != nil {
 		return errc
 	}
-
-	name := d.Get("name").(string)
 
 	_, err := resourceMailgunDomainRetrieve(name, client, d)
 

--- a/mailgun/resource_mailgun_route.go
+++ b/mailgun/resource_mailgun_route.go
@@ -88,7 +88,7 @@ func resourceMailgunRouteCreate(ctx context.Context, d *schema.ResourceData, met
 	route, err := client.CreateRoute(context.Background(), opts)
 
 	if err != nil {
-		return diag.FromErr(errc)
+		return diag.FromErr(err)
 	}
 
 	d.SetId(route.Id)
@@ -99,7 +99,7 @@ func resourceMailgunRouteCreate(ctx context.Context, d *schema.ResourceData, met
 	_, err = resourceMailgunRouteRetrieve(d.Id(), client, d)
 
 	if err != nil {
-		return diag.FromErr(errc)
+		return diag.FromErr(err)
 	}
 
 	return nil
@@ -201,6 +201,10 @@ func resourceMailgunRouteRetrieve(id string, client *mailgun.Client, d *schema.R
 	_ = d.Set("description", route.Description)
 	_ = d.Set("expression", route.Expression)
 	_ = d.Set("actions", route.Actions)
+	// Region is not returned by API, preserve it from state
+	if region, ok := d.GetOk("region"); ok {
+		_ = d.Set("region", region)
+	}
 
 	return &route, nil
 }


### PR DESCRIPTION
Tested locally
- create a route in `"eu"` region with provider `0.7.7`
- upgrade to provider `0.8.0` - run `terraform plan` -> `route not found` error occurs
- use `.terraformrc` override - no error occurs 

## Summary

Fixes three critical bugs preventing `mailgun_route` resources from working correctly:
1. **Inconsistent result error** - Route state missing `region` field
2. **Incorrect error handling** - Wrong error variable being returned
3. **API base URL error** - Version included in base URL when library handles it internally

## Problems Fixed

### 1. "Provider produced inconsistent result after apply" Error
**Cause**: `region` field wasn't preserved in state during Read operations  
**Fix**: Preserve `region` from existing state in `resourceMailgunRouteRetrieve`

### 2. Incorrect Error Handling
**Cause**: Using `errc` instead of `err` in error returns  
**Fix**: Changed to `diag.FromErr(err)` in route create function

### 3. API Base URL Configuration
**Cause**: Base URL included `/v3` but library expects host only  - v5 library changed `SetAPIBase()` to reject URLs containing version numbers.
**Fix**: Removed version from base URLs (`https://api.eu.mailgun.net` not `https://api.eu.mailgun.net/v3`)

