### PR TITLE
Feat: Add support for Automatic Sender Security

### DIFF
--- a/docs/resources/domain.md
+++ b/docs/resources/domain.md
@@ -78,6 +78,7 @@ The following arguments are supported:
 * `open_tracking` - (Optional) (Enum: `yes` or `no`) The open tracking settings for the domain. Default: `no`
 * `click_tracking` - (Optional) (Enum: `yes` or `no`) The click tracking settings for the domain. Default: `no`
 * `web_scheme` - (Optional) (`http` or `https`) The tracking web scheme. Default: `http`
+* `use_automatic_sender_security` - (Optional) If true Mailgun manages DKIM key generation and DNS record configuration automatically. Default: `false`
 
 ## Attributes Reference
 
@@ -92,6 +93,7 @@ The following attributes are exported:
 * `open_tracking` - The open tracking setting.
 * `click_tracking` - The click tracking setting.
 * `web_scheme` - The tracking web scheme.
+* `use_automatic_sender_security` - Whether or not automatic sender sender security is enabled.
 * `receiving_records` - A list of DNS records for receiving validation.  **Deprecated** Use `receiving_records_set` instead.
   * `priority` - The priority of the record.
   * `record_type` - The record type.

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -3,10 +3,11 @@ package mailgun
 import (
 	"context"
 	"fmt"
-	"github.com/mailgun/mailgun-go/v5/mtypes"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/mailgun/mailgun-go/v5/mtypes"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -220,6 +221,12 @@ func resourceMailgunDomain() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"use_automatic_sender_security": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
 		},
 		CustomizeDiff: customdiff.Sequence(
 			func(_ context.Context, diff *schema.ResourceDiff, v interface{}) error {
@@ -353,6 +360,7 @@ func resourceMailgunDomainCreate(ctx context.Context, d *schema.ResourceData, me
 	opts.Wildcard = d.Get("wildcard").(bool)
 	opts.DKIMKeySize = d.Get("dkim_key_size").(int)
 	opts.ForceDKIMAuthority = d.Get("force_dkim_authority").(bool)
+	opts.UseAutomaticSenderSecurity = d.Get("use_automatic_sender_security").(bool)
 	opts.WebScheme = d.Get("web_scheme").(string)
 	var dkimSelector = d.Get("dkim_selector").(string)
 	var openTracking = d.Get("open_tracking").(bool)
@@ -464,6 +472,7 @@ func resourceMailgunDomainRetrieve(id string, client *mailgun.Client, d *schema.
 	_ = d.Set("wildcard", resp.Domain.Wildcard)
 	_ = d.Set("spam_action", resp.Domain.SpamAction)
 	_ = d.Set("web_scheme", resp.Domain.WebScheme)
+	_ = d.Set("use_automatic_sender_security", resp.Domain.UseAutomaticSenderSecurity)
 
 	receivingRecords := make([]map[string]interface{}, len(resp.ReceivingDNSRecords))
 	for i, r := range resp.ReceivingDNSRecords {

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/mailgun/mailgun-go/v5/mtypes"
@@ -493,6 +494,10 @@ func resourceMailgunDomainRetrieve(id string, client *mailgun.Client, d *schema.
 		sendingRecords[i]["valid"] = r.Valid
 		sendingRecords[i]["value"] = r.Value
 		sendingRecords[i]["record_type"] = r.RecordType
+
+		if strings.Contains(r.Name, "._domainkey.") && !resp.Domain.UseAutomaticSenderSecurity {
+			sendingRecords[i]["id"] = "_domainkey." + resp.Domain.Name
+		}
 	}
 	_ = d.Set("sending_records", sendingRecords)
 	_ = d.Set("sending_records_set", sendingRecords)

--- a/mailgun/resource_mailgun_domain.go
+++ b/mailgun/resource_mailgun_domain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"github.com/mailgun/mailgun-go/v5/mtypes"
@@ -494,10 +493,6 @@ func resourceMailgunDomainRetrieve(id string, client *mailgun.Client, d *schema.
 		sendingRecords[i]["valid"] = r.Valid
 		sendingRecords[i]["value"] = r.Value
 		sendingRecords[i]["record_type"] = r.RecordType
-
-		if strings.Contains(r.Name, "._domainkey.") {
-			sendingRecords[i]["id"] = "_domainkey." + resp.Domain.Name
-		}
 	}
 	_ = d.Set("sending_records", sendingRecords)
 	_ = d.Set("sending_records_set", sendingRecords)

--- a/mailgun/resource_mailgun_domain_test.go
+++ b/mailgun/resource_mailgun_domain_test.go
@@ -45,6 +45,8 @@ func TestAccMailgunDomain_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"mailgun_domain.foobar", "web_scheme", "https"),
 					resource.TestCheckResourceAttr(
+						"mailgun_domain.foobar", "use_automatic_sender_security", "true"),
+					resource.TestCheckResourceAttr(
 						"mailgun_domain.foobar", "receiving_records.0.priority", "10"),
 					resource.TestMatchResourceAttr(
 						"mailgun_domain.foobar", "sending_records.0.name", re),
@@ -121,6 +123,10 @@ func testAccCheckMailgunDomainAttributes(domain string, DomainResp *mtypes.GetDo
 			return fmt.Errorf("Bad web scheme: %s", DomainResp.Domain.WebScheme)
 		}
 
+		if DomainResp.Domain.UseAutomaticSenderSecurity != true {
+			return fmt.Errorf("Bad use_automatic_sender_security: %t", DomainResp.Domain.UseAutomaticSenderSecurity)
+		}
+
 		if DomainResp.ReceivingDNSRecords[0].Priority == "" {
 			return fmt.Errorf("Bad receiving_records: %#v", DomainResp.ReceivingDNSRecords[0].Priority)
 		}
@@ -177,5 +183,6 @@ resource "mailgun_domain" "foobar" {
 	open_tracking = true
 	click_tracking = true
 	web_scheme = "https"
+	use_automatic_sender_security = true
 }`
 }


### PR DESCRIPTION
Adds support for `use_automatic_sender_security` when creating a domain.

> use_automatic_sender_security
> 
> Enable or disable Automatic Sender Security. If enabled, requires setting DNS CNAME entries for DKIM keys instead of a TXT record. Defaults to false

