### PR TITLE
feat(webhook): adding import support

### DIFF
--- a/docs/resources/webhook.md
+++ b/docs/resources/webhook.md
@@ -36,3 +36,17 @@ The following attributes are exported:
 * `region` - The name of the region.
 * `kind` - The kind of the webhook.
 * `urls` - The urls of the webhook.
+
+## Import
+
+Webhooks can be imported using the `region:domain:kind` or `domain:kind` format:
+
+```
+terraform import mailgun_webhook.default us:test.example.com:delivered
+```
+
+or using the default region (us):
+
+```
+terraform import mailgun_webhook.default test.example.com:delivered
+```

--- a/mailgun/resource_mailgun_webhook.go
+++ b/mailgun/resource_mailgun_webhook.go
@@ -70,21 +70,25 @@ func resourceMailgunWebhookImport(ctx context.Context, d *schema.ResourceData, m
 	parts := strings.SplitN(d.Id(), ":", 3)
 	log.Printf("[DEBUG] Split parts: %v", parts)
 
-	if len(parts) == 3 {
-		// Format: region:domain:kind
-		log.Printf("[DEBUG] Setting region=%s, domain=%s, kind=%s", parts[0], parts[1], parts[2])
-		_ = d.Set("region", parts[0])
-		_ = d.Set("domain", parts[1])
-		_ = d.Set("kind", parts[2])
-	} else if len(parts) == 2 {
-		// Format: domain:kind (use default region)
-		log.Printf("[DEBUG] Setting region=us, domain=%s, kind=%s", parts[0], parts[1])
-		_ = d.Set("region", "us")
-		_ = d.Set("domain", parts[0])
-		_ = d.Set("kind", parts[1])
-	} else {
+	var region, domain, kind string
+
+	switch len(parts) {
+	case 2:
+		region = "us"
+		domain = parts[0]
+		kind = parts[1]
+	case 3:
+		region = parts[0]
+		domain = parts[1]
+		kind = parts[2]
+	default:
 		return nil, fmt.Errorf("invalid import ID format. Expected 'region:domain:kind' or 'domain:kind'")
 	}
+
+	log.Printf("[DEBUG] Setting region=%s, domain=%s, kind=%s", region, domain, kind)
+	_ = d.Set("region", region)
+	_ = d.Set("domain", domain)
+	_ = d.Set("kind", kind)
 
 	log.Printf("[DEBUG] After setting - region: %s, domain: %s, kind: %s", d.Get("region"), d.Get("domain"), d.Get("kind"))
 	return []*schema.ResourceData{d}, nil

--- a/mailgun/resource_mailgun_webhook.go
+++ b/mailgun/resource_mailgun_webhook.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -65,8 +66,27 @@ func resourceMailgunWebhook() *schema.Resource {
 }
 
 func resourceMailgunWebhookImport(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	setDefaultRegionForImport(d)
+	log.Printf("[DEBUG] Import ID: %s", d.Id())
+	parts := strings.SplitN(d.Id(), ":", 3)
+	log.Printf("[DEBUG] Split parts: %v", parts)
 
+	if len(parts) == 3 {
+		// Format: region:domain:kind
+		log.Printf("[DEBUG] Setting region=%s, domain=%s, kind=%s", parts[0], parts[1], parts[2])
+		_ = d.Set("region", parts[0])
+		_ = d.Set("domain", parts[1])
+		_ = d.Set("kind", parts[2])
+	} else if len(parts) == 2 {
+		// Format: domain:kind (use default region)
+		log.Printf("[DEBUG] Setting region=us, domain=%s, kind=%s", parts[0], parts[1])
+		_ = d.Set("region", "us")
+		_ = d.Set("domain", parts[0])
+		_ = d.Set("kind", parts[1])
+	} else {
+		return nil, fmt.Errorf("invalid import ID format. Expected 'region:domain:kind' or 'domain:kind'")
+	}
+
+	log.Printf("[DEBUG] After setting - region: %s, domain: %s, kind: %s", d.Get("region"), d.Get("domain"), d.Get("kind"))
 	return []*schema.ResourceData{d}, nil
 }
 


### PR DESCRIPTION
Hello !
I was not able to import some existing webhook using :
```hcl
resource "mailgun_webhook" "example_com" {
  domain = "example.com"
  region = "us"
  kind   = "opened"
  urls = ["https://api.example.com/v1/mailgun/example-hooks", "https://next.api.example.com/v1/mailgun/example-hooks", "https://staging.api.example.com/v1/mailgun/example-hooks"]
}

import {
  id = "us:example.com:opened"
  to = mailgun_webhook.example_com
}

```

resulting in :
```
mailgun_webhook.example_com: Preparing import... [id=us:example.com:opened]
mailgun_webhook.example_com: Refreshing state... [id=example.com:opened]

Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: UnexpectedResponseError Method=GET URL=https://api.mailgun.net/v3/domains//webhooks/ ExpectedOneOf=[]int{200, 202, 204} Got=404 Error: {"error":"not found"}
│
│
╵
```

after this fix: 
```
mailgun_webhook.example_com: Preparing import... [id=us:example.com:opened]
mailgun_webhook.example_com: Refreshing state... [id=us:example.com:opened]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place

Terraform will perform the following actions:

  # mailgun_webhook.example_com will be updated in-place
  # (imported from "us:example.com:opened")
  ~ resource "mailgun_webhook" "example_com" {
        domain = "example.com"
        id     = "us:example.com:opened"
        kind   = "opened"
        region = "us"
      ~ urls   = [
            "https://api.example.com/v1/mailgun/example-hooks",
            "https://next.api.example.com/v1/mailgun/example-hooks",
          + "https://staging.api.example.com/v1/mailgun/example-hooks",
        ]
    }

Plan: 1 to import, 0 to add, 1 to change, 0 to destroy.
```